### PR TITLE
Use of Pathlib's Path and Fix of Windows-Specific Problems

### DIFF
--- a/ergup.er
+++ b/ergup.er
@@ -32,7 +32,7 @@ remove_readonly!(func, path: Path, _: Obj) =
 
 
 install_poise!() =
-    poise_git_url = "https://github.com/erg-lang/poise.git"
+
     print! "Cloning poise (erg package manager) ..."
     if! not(erg_tmp_dir.exists!()), do!:
         erg_tmp_dir.mkdir!(parents:=True, exist_ok:=True)
@@ -44,7 +44,7 @@ install_poise!() =
         cmd = ["git", "clone", "https://github.com/erg-lang/poise.git"]
         clone_res = sub.run! cmd, capture_output:=True
         if! clone_res.returncode != 0, do!:
-        panic "Failed to clone poise repo"
+            panic "Failed to clone poise repo"
 
     os.chdir! poise
 
@@ -57,26 +57,27 @@ install_poise!() =
         panic "Failed to install poise: \{install_res.stderr.decode()}"
 
     print! "poise installed successfully"
+
     os.chdir! ".."
     su.rmtree! poise, onerror:=remove_readonly!
 
-overwrite = !False
-if! os.path.exists!(erg_dir), do!:
+
+is_overwrite = !False
 if! erg_dir.exists!(), do!:
-    answer = input!()
-    overwrite.update! _ -> answer == "y"
-    if! overwrite:
+    answer = input!(".erg directory already exists, do you want to overwrite it? [y/n] ")
+    is_overwrite.update! _ -> answer == "y"
+    if! is_overwrite:
         do!:
             print! "Removing \{erg_dir} ..."
             su.rmtree! erg_dir, onerror:=remove_readonly!
 
         do!:
             if! sub.run!("poise", capture_output := True, shell := True).returncode != 0, do!:
-                print! "poise is not installed, do you want to install it? [y/n]", end:=" "
-                answer = input!()
+                answer = input!("poise is not installed, do you want to install it? [y/n] ")
                 if! answer == "y", do!:
                     install_poise!()
                     exit 0
+
             print! "Aborting installation"
             exit 1
 
@@ -91,6 +92,7 @@ latest_version = if! sys.argv.get(1) == "nightly":
         jdata = json.loads s
         assert jdata in List({Str: Obj})
         jdata[0]["tag_name"]
+
     do!:
         LATEST_URL = "https://api.github.com/repos/erg-lang/erg/releases/latest"
         _stream = request.urlopen!(LATEST_URL)
@@ -101,7 +103,7 @@ latest_version = if! sys.argv.get(1) == "nightly":
 
 print! "version: \{latest_version}"
 
-filename = match sys.platform:
+filename = match platform:
     "darwin" -> "erg-x86_64-apple-darwin.tar.gz"
     "win32" -> "erg-x86_64-pc-windows-msvc.zip"
     _ -> "erg-x86_64-unknown-linux-gnu.tar.gz"
@@ -116,14 +118,11 @@ if! platform == "win32":
         zipfile = zf.ZipFile! bytesio
         zipfile.extractall! erg_tmp_dir
         zipfile.close!()
-        discard su.move! "\{erg_tmp_dir}/erg.exe", "\{erg_bin_dir}/erg.exe"
-        discard su.move! "\{erg_tmp_dir}/lib", "\{erg_dir}/lib"
-        su.rmtree! erg_tmp_dir
     do!:
-        print! "Extracting \{filename} ..."
         tarfile = tf.open!(fileobj:=stream, mode:="r|gz")
         tarfile.extractall! erg_tmp_dir
         tarfile.close!()
+
 erg_tmp_bin = erg_tmp_dir.joinpath(ext)
 discard su.move! erg_tmp_bin, erg_bin
 discard su.move! erg_tmp_dir.joinpath("lib"), erg_dir.joinpath("lib")
@@ -134,5 +133,5 @@ print! "erg installed successfully"
 
 install_poise!()
 
-if! not(overwrite), do!:
+if! not(is_overwrite), do!:
     print! "Please add `.erg` to your PATH by running `export PATH=$PATH:\{erg_bin_dir}` and `export ERG_PATH=\{erg_dir}`"

--- a/ergup.er
+++ b/ergup.er
@@ -7,34 +7,55 @@ os = pyimport "os"
 io = pyimport "io"
 su = pyimport "shutil"
 sub = pyimport "subprocess"
+{Path;} = pyimport "pathlib"
 
-homedir = os.path.expanduser! "~"
-erg_dir = homedir + "/.erg"
-erg_bin_dir = homedir + "/.erg/bin"
-erg_tmp_dir = homedir + "/.erg/tmp"
+
+home_dir = Path.home!()
+erg_dir = home_dir.joinpath(".erg")
+erg_bin_dir = erg_dir.joinpath("bin")
+erg_tmp_dir = erg_dir.joinpath("tmp")
+
+platform = sys.platform
+
+ext = if! platform == "win32":
+    do! "erg.exe"
+    do! "erg"
+
+erg_bin = erg_bin_dir.joinpath(ext).resolve!()
+
 
 install_poise!() =
     poise_git_url = "https://github.com/erg-lang/poise.git"
     print! "Cloning poise (erg package manager) ..."
-    if! not(os.path.exists!(erg_tmp_dir)), do!:
-        os.mkdir! erg_tmp_dir
+    if! not(erg_tmp_dir.exists!()), do!:
+        erg_tmp_dir.mkdir!(parents:=True, exist_ok:=True)
+
     os.chdir! erg_tmp_dir
-    res = sub.run! ["git", "clone", poise_git_url], capture_output:=True
-    if! res.returncode != 0, do!:
+
+    poise = Path("poise")
+    if! not(poise.exists!()), do!:
+        cmd = ["git", "clone", "https://github.com/erg-lang/poise.git"]
+        clone_res = sub.run! cmd, capture_output:=True
+        if! clone_res.returncode != 0, do!:
         panic "Failed to clone poise repo"
-    os.chdir! "poise"
+
+    os.chdir! poise
+
     print! "Building poise ..."
-    res2 = sub.run! ["\{erg_bin_dir}/erg", "src/main.er", "--", "install"], capture_output:=True
-    if! res2.returncode != 0, do!:
-        assert res2.stderr in Bytes
-        panic "Failed to install poise: \{res2.stderr.decode()}"
+    poise_main_path = Path("src", "main.er")
+    cmd = ["\{erg_bin}", "\{poise_main_path}", "--", "install"]
+    install_res = sub.run! cmd, capture_output:=True
+    if! install_res.returncode != 0, do!:
+        assert install_res.stderr in Bytes
+        panic "Failed to install poise: \{install_res.stderr.decode()}"
+
     print! "poise installed successfully"
     os.chdir! ".."
     su.rmtree! "poise"
 
 overwrite = !False
 if! os.path.exists!(erg_dir), do!:
-    print! ".erg directory already exists, do you want to overwrite it? [y/n]", end:=" "
+if! erg_dir.exists!(), do!:
     answer = input!()
     overwrite.update! _ -> answer == "y"
     if! overwrite:
@@ -51,8 +72,8 @@ if! os.path.exists!(erg_dir), do!:
             print! "Aborting installation"
             exit 1
 
-os.mkdir! erg_dir
-os.mkdir! erg_bin_dir
+erg_dir.mkdir!(parents:=True, exist_ok:=True)
+erg_bin_dir.mkdir!(parents:=True, exist_ok:=True)
 
 latest_version = if! sys.argv.get(1) == "nightly":
     do!:
@@ -96,9 +117,10 @@ if! sys.platform == "win32":
         tarfile = tf.open!(fileobj:=stream, mode:="r|gz")
         tarfile.extractall! erg_tmp_dir
         tarfile.close!()
-        discard su.move! "\{erg_tmp_dir}/erg", "\{erg_bin_dir}/erg"
-        discard su.move! "\{erg_tmp_dir}/lib", "\{erg_dir}/lib"
-        su.rmtree! erg_tmp_dir
+erg_tmp_bin = erg_tmp_dir.joinpath(ext)
+discard su.move! erg_tmp_bin, erg_bin
+discard su.move! erg_tmp_dir.joinpath("lib"), erg_dir.joinpath("lib")
+
 
 print! "erg installed successfully"
 

--- a/ergup.er
+++ b/ergup.er
@@ -1,4 +1,3 @@
-urllib = pyimport "urllib"
 tf = pyimport "tarfile"
 zf = pyimport "zipfile"
 json = pyimport "json"
@@ -8,6 +7,7 @@ io = pyimport "io"
 su = pyimport "shutil"
 sub = pyimport "subprocess"
 {Path;} = pyimport "pathlib"
+{request;} = pyimport "urllib"
 
 
 home_dir = Path.home!()
@@ -77,15 +77,15 @@ erg_bin_dir.mkdir!(parents:=True, exist_ok:=True)
 
 latest_version = if! sys.argv.get(1) == "nightly":
     do!:
-        latest_url = "https://api.github.com/repos/erg-lang/erg/releases"
-        _stream = urllib.request.urlopen!(latest_url)
+        LATEST_URL = "https://api.github.com/repos/erg-lang/erg/releases"
+        _stream = request.urlopen!(LATEST_URL)
         s = _stream.read!().decode()
         jdata = json.loads s
         assert jdata in List({Str: Obj})
         jdata[0]["tag_name"]
     do!:
-        latest_url = "https://api.github.com/repos/erg-lang/erg/releases/latest"
-        _stream = urllib.request.urlopen!(latest_url)
+        LATEST_URL = "https://api.github.com/repos/erg-lang/erg/releases/latest"
+        _stream = request.urlopen!(LATEST_URL)
         s = _stream.read!().decode()
         jdata = json.loads s
         assert jdata in {Str: Obj}
@@ -100,11 +100,10 @@ filename = match sys.platform:
 url = "https://github.com/erg-lang/erg/releases/download/\{latest_version}/\{filename}"
 
 print! "Downloading \{url} ..."
-
-stream = urllib.request.urlopen!(url)
-if! sys.platform == "win32":
+stream = request.urlopen!(url)
+print! "Extracting \{filename} ..."
+if! platform == "win32":
     do!:
-        print! "Extracting \{filename} ..."
         bytesio = io.BytesIO! stream.read!()
         zipfile = zf.ZipFile! bytesio
         zipfile.extractall! erg_tmp_dir

--- a/ergup.er
+++ b/ergup.er
@@ -7,6 +7,7 @@ io = pyimport "io"
 su = pyimport "shutil"
 sub = pyimport "subprocess"
 {Path;} = pyimport "pathlib"
+{S_IWRITE;} = pyimport "stat"
 {request;} = pyimport "urllib"
 
 
@@ -22,6 +23,12 @@ ext = if! platform == "win32":
     do! "erg"
 
 erg_bin = erg_bin_dir.joinpath(ext).resolve!()
+
+
+remove_readonly!(func, path: Path, _: Obj) =
+
+    os.chmod! path, S_IWRITE
+    func(path)
 
 
 install_poise!() =
@@ -51,7 +58,7 @@ install_poise!() =
 
     print! "poise installed successfully"
     os.chdir! ".."
-    su.rmtree! "poise"
+    su.rmtree! poise, onerror:=remove_readonly!
 
 overwrite = !False
 if! os.path.exists!(erg_dir), do!:
@@ -61,7 +68,8 @@ if! erg_dir.exists!(), do!:
     if! overwrite:
         do!:
             print! "Removing \{erg_dir} ..."
-            su.rmtree! erg_dir
+            su.rmtree! erg_dir, onerror:=remove_readonly!
+
         do!:
             if! sub.run!("poise", capture_output := True, shell := True).returncode != 0, do!:
                 print! "poise is not installed, do you want to install it? [y/n]", end:=" "
@@ -120,6 +128,7 @@ erg_tmp_bin = erg_tmp_dir.joinpath(ext)
 discard su.move! erg_tmp_bin, erg_bin
 discard su.move! erg_tmp_dir.joinpath("lib"), erg_dir.joinpath("lib")
 
+su.rmtree! erg_tmp_dir, onerror:=remove_readonly!
 
 print! "erg installed successfully"
 

--- a/ergup.py
+++ b/ergup.py
@@ -209,10 +209,12 @@ class UnionType:
 
 
 class FakeGenericAlias:
+    __name__: str
     __origin__: type
     __args__: list  # list[type]
 
     def __init__(self, origin, *args):
+        self.__name__ = origin.__name__
         self.__origin__ = origin
         self.__args__ = args
 
@@ -1191,8 +1193,17 @@ class Bytes(bytes):
             return Bytes(bytes.__getitem__(self, index_or_slice.into_slice()))
         else:
             return bytes.__getitem__(self, index_or_slice)
-os_L6 = __import__("os.path")
-os_L6 = __import__("os.path")
+__percent__v_desugar_3_L11 = __import__("urllib.request")
+def if_tmp_func_1__():
+    if (not ((poise_L42_C4).exists())):
+        global cmd_L44_C8
+        cmd_L44_C8 = List([Str("git"),Str("clone"),Str("https://github.com/erg-lang/poise.git"),])
+        global clone_res_L45_C8
+        clone_res_L45_C8 = (sub_L8).run(List(cmd_L44_C8),capture_output=Bool(True),)
+        if_tmp_0__ = (quit)(Str("Failed to clone poise repo"),) if (Int((clone_res_L45_C8).returncode) != Nat(0)) else None
+    else:
+        if_tmp_0__ = None
+    return if_tmp_0__
 
 
 
@@ -1213,166 +1224,160 @@ def float__(f):
 
 def str__(s):
     return Str(s)
-def if_tmp_func_1__():
-    if (Int((res2_L27_C4).returncode) != Nat(0)):
-        assert contains_operator(Bytes,(res2_L27_C4).stderr)
-        if_tmp_0__ = (quit)(((Str("Failed to install poise: ") + (str__)((Bytes((res2_L27_C4).stderr)).decode(),)) + Str("")),)
+def if_tmp_func_3__():
+    if (Int((install_res_L54_C4).returncode) != Nat(0)):
+        assert contains_operator(Bytes,(install_res_L54_C4).stderr)
+        if_tmp_2__ = (quit)(((Str("Failed to install poise: ") + (str__)((Bytes((install_res_L54_C4).stderr)).decode(),)) + Str("")),)
     else:
-        if_tmp_0__ = None
-    return if_tmp_0__
+        if_tmp_2__ = None
+    return if_tmp_2__
 def mutate_operator(x):
     if hasattr(x, "mutate"):
         return x.mutate()
     else:
         return x
-os_L6 = __import__("os.path")
+def if_tmp_func_12__():
+    if (Str(answer_L76_C16) == Str("y")):
+        (install_poise__erg_proc___L34)()
+        if_tmp_11__ = (exit)(Nat(0),)
+    else:
+        if_tmp_11__ = None
+    return if_tmp_11__
 def if_tmp_func_10__():
-    if (Str(answer_L47_C16) == Str("y")):
-        (install_poise__erg_proc___L16)()
-        if_tmp_9__ = (exit)(Nat(0),)
+    if (Int(((sub_L8).run(Str("poise"),capture_output=Bool(True),shell=Bool(True),)).returncode) != Nat(0)):
+        global answer_L76_C16
+        answer_L76_C16 = (input)(Str("poise is not installed, do you want to install it? [y/n] "),)
+        if_tmp_9__ = if_tmp_func_12__()
     else:
         if_tmp_9__ = None
     return if_tmp_9__
 def if_tmp_func_8__():
-    if (Int(((sub_L9).run(Str("poise"),capture_output=Bool(True),shell=Bool(True),)).returncode) != Nat(0)):
-        (print)(Str("poise is not installed, do you want to install it? [y/n]"),end=Str(" "),)
-        global answer_L47_C16
-        answer_L47_C16 = (input)()
-        if_tmp_7__ = if_tmp_func_10__()
+    if is_overwrite_L65:
+        (print)(((Str("Removing ") + (str__)(erg_dir_L15,)) + Str(" ...")),)
+        if_tmp_7__ = (su_L7).rmtree(erg_dir_L15,onerror=remove_readonly__erg_proc___L28,)
     else:
-        if_tmp_7__ = None
-    return if_tmp_7__
-def if_tmp_func_6__():
-    if overwrite_L35:
-        (print)(((Str("Removing ") + (str__)(Str(erg_dir_L12),)) + Str(" ...")),)
-        if_tmp_5__ = (su_L8).rmtree(Str(erg_dir_L12),)
-    else:
-        if_tmp_func_8__()
+        if_tmp_func_10__()
         (print)(Str("Aborting installation"),)
-        if_tmp_5__ = (exit)(Nat(1),)
-    return if_tmp_5__
-def if_tmp_func_3__():
-    if (
-(os_L6).path
-).exists(Str(erg_dir_L12),):
-        (print)(Str(".erg directory already exists, do you want to overwrite it? [y/n]"),end=Str(" "),)
-        global answer_L38_C4
-        answer_L38_C4 = (input)()
-        (overwrite_L35).update((lambda _4,:            (Str(answer_L38_C4) == Str("y"))),)
-        if_tmp_2__ = if_tmp_func_6__()
+        if_tmp_7__ = (exit)(Nat(1),)
+    return if_tmp_7__
+def if_tmp_func_5__():
+    if (erg_dir_L15).exists():
+        global answer_L67_C4
+        answer_L67_C4 = (input)(Str(".erg directory already exists, do you want to overwrite it? [y/n] "),)
+        (is_overwrite_L65).update((lambda _6,:            (Str(answer_L67_C4) == Str("y"))),)
+        if_tmp_4__ = if_tmp_func_8__()
     else:
-        if_tmp_2__ = None
-    return if_tmp_2__
-urllib_L1 = __import__("urllib.request")
-urllib_L1 = __import__("urllib.request")
-def if_tmp_func_12__():
-    if ((List((sys_L5).argv)).get(Nat(1),) == Str("nightly")):
-        global latest_url_L59_C8
-        latest_url_L59_C8 = Str("https://api.github.com/repos/erg-lang/erg/releases")
-        global _stream_L60_C8
-        _stream_L60_C8 = (
-        (urllib_L1).request
-        ).urlopen(Str(latest_url_L59_C8),)
-        global s_L61_C8
-        s_L61_C8 = ((_stream_L60_C8).read()).decode()
-        global jdata_L62_C8
-        jdata_L62_C8 = (json_L4).loads(Str(s_L61_C8),)
-        assert contains_operator((List)[Dict({(Str): (object),}),],jdata_L62_C8)
-        if_tmp_11__ = ((List(jdata_L62_C8)).__getitem__(Nat(0),)).__getitem__(Str("tag_name"),)
+        if_tmp_4__ = None
+    return if_tmp_4__
+def if_tmp_func_14__():
+    if ((List((sys_L4).argv)).get(Nat(1),) == Str("nightly")):
+        global LATEST_URL_L89_C8
+        LATEST_URL_L89_C8 = Str("https://api.github.com/repos/erg-lang/erg/releases")
+        global _stream_L90_C8
+        _stream_L90_C8 = (request_L11_C1).urlopen(Str(LATEST_URL_L89_C8),)
+        global s_L91_C8
+        s_L91_C8 = ((_stream_L90_C8).read()).decode()
+        global jdata_L92_C8
+        jdata_L92_C8 = (json_L3).loads(Str(s_L91_C8),)
+        assert contains_operator((List)[Dict({(Str): (object),}),],jdata_L92_C8)
+        if_tmp_13__ = ((List(jdata_L92_C8)).__getitem__(Nat(0),)).__getitem__(Str("tag_name"),)
     else:
-        global latest_url_L66_C8
-        latest_url_L66_C8 = Str("https://api.github.com/repos/erg-lang/erg/releases/latest")
-        global _stream_L67_C8
-        _stream_L67_C8 = (
-        (urllib_L1).request
-        ).urlopen(Str(latest_url_L66_C8),)
-        global s_L68_C8
-        s_L68_C8 = ((_stream_L67_C8).read()).decode()
-        global jdata_L69_C8
-        jdata_L69_C8 = (json_L4).loads(Str(s_L68_C8),)
-        assert contains_operator(Dict({(Str): (object),}),jdata_L69_C8)
-        if_tmp_11__ = (Dict(jdata_L69_C8)).__getitem__(Str("tag_name"),)
-    return if_tmp_11__
-def match_tmp_func_14__():
-    match Str((sys_L5).platform):
-        case ("darwin") as __percent__p_desugar_1_L76_C4:
-            match_tmp_13__ = Str("erg-x86_64-apple-darwin.tar.gz")
-        case ("win32") as __percent__p_desugar_2_L77_C4:
-            match_tmp_13__ = Str("erg-x86_64-pc-windows-msvc.zip")
+        global LATEST_URL_L97_C8
+        LATEST_URL_L97_C8 = Str("https://api.github.com/repos/erg-lang/erg/releases/latest")
+        global _stream_L98_C8
+        _stream_L98_C8 = (request_L11_C1).urlopen(Str(LATEST_URL_L97_C8),)
+        global s_L99_C8
+        s_L99_C8 = ((_stream_L98_C8).read()).decode()
+        global jdata_L100_C8
+        jdata_L100_C8 = (json_L3).loads(Str(s_L99_C8),)
+        assert contains_operator(Dict({(Str): (object),}),jdata_L100_C8)
+        if_tmp_13__ = (Dict(jdata_L100_C8)).__getitem__(Str("tag_name"),)
+    return if_tmp_13__
+def match_tmp_func_16__():
+    match Str(platform_L19):
+        case ("darwin") as __percent__p_desugar_4_L107_C4:
+            match_tmp_15__ = Str("erg-x86_64-apple-darwin.tar.gz")
+        case ("win32") as __percent__p_desugar_5_L108_C4:
+            match_tmp_15__ = Str("erg-x86_64-pc-windows-msvc.zip")
         case _:
-            match_tmp_13__ = Str("erg-x86_64-unknown-linux-gnu.tar.gz")
-    return match_tmp_13__
-urllib_L1 = __import__("urllib.request")
-def if_tmp_func_16__():
-    if (Str((sys_L5).platform) == Str("win32")):
-        (print)(((Str("Extracting ") + (str__)(Str(filename_L75),)) + Str(" ...")),)
-        global bytesio_L87_C8
-        bytesio_L87_C8 = (io_L7).BytesIO((stream_L83).read(),)
-        global zipfile_L88_C8
-        zipfile_L88_C8 = (zf_L3).ZipFile(bytesio_L87_C8,)
-        (zipfile_L88_C8).extractall(Str(erg_tmp_dir_L14),)
-        (zipfile_L88_C8).close()
-        (discard__)((su_L8).move(((Str("") + (str__)(Str(erg_tmp_dir_L14),)) + Str("/erg.exe")),((Str("") + (str__)(Str(erg_bin_dir_L13),)) + Str("/erg.exe")),),)
-        (discard__)((su_L8).move(((Str("") + (str__)(Str(erg_tmp_dir_L14),)) + Str("/lib")),((Str("") + (str__)(Str(erg_dir_L12),)) + Str("/lib")),),)
-        if_tmp_15__ = (su_L8).rmtree(Str(erg_tmp_dir_L14),)
+            match_tmp_15__ = Str("erg-x86_64-unknown-linux-gnu.tar.gz")
+    return match_tmp_15__
+def if_tmp_func_18__():
+    if (Str(platform_L19) == Str("win32")):
+        global bytesio_L117_C8
+        bytesio_L117_C8 = (io_L6).BytesIO((stream_L113).read(),)
+        global zipfile_L118_C8
+        zipfile_L118_C8 = (zf_L2).ZipFile(bytesio_L117_C8,)
+        (zipfile_L118_C8).extractall(erg_tmp_dir_L17,)
+        if_tmp_17__ = (zipfile_L118_C8).close()
     else:
-        (print)(((Str("Extracting ") + (str__)(Str(filename_L75),)) + Str(" ...")),)
-        global tarfile_L96_C8
-        tarfile_L96_C8 = (tf_L2).open(fileobj=stream_L83,mode=Str("r|gz"),)
-        (tarfile_L96_C8).extractall(Str(erg_tmp_dir_L14),)
-        (tarfile_L96_C8).close()
-        (discard__)((su_L8).move(((Str("") + (str__)(Str(erg_tmp_dir_L14),)) + Str("/erg")),((Str("") + (str__)(Str(erg_bin_dir_L13),)) + Str("/erg")),),)
-        (discard__)((su_L8).move(((Str("") + (str__)(Str(erg_tmp_dir_L14),)) + Str("/lib")),((Str("") + (str__)(Str(erg_dir_L12),)) + Str("/lib")),),)
-        if_tmp_15__ = (su_L8).rmtree(Str(erg_tmp_dir_L14),)
-    return if_tmp_15__
-urllib_L1 = (__import__)(Str("urllib"),)
-tf_L2 = (__import__)(Str("tarfile"),)
-zf_L3 = (__import__)(Str("zipfile"),)
-json_L4 = (__import__)(Str("json"),)
-sys_L5 = (__import__)(Str("sys"),)
-os_L6 = (__import__)(Str("os"),)
-io_L7 = (__import__)(Str("io"),)
-su_L8 = (__import__)(Str("shutil"),)
-sub_L9 = (__import__)(Str("subprocess"),)
-homedir_L11 = (
-(os_L6).path
-).expanduser(Str("~"),)
-erg_dir_L12 = (Str(homedir_L11) + Str("/.erg"))
-erg_bin_dir_L13 = (Str(homedir_L11) + Str("/.erg/bin"))
-erg_tmp_dir_L14 = (Str(homedir_L11) + Str("/.erg/tmp"))
-def install_poise__erg_proc___L16():
-    global poise_git_url_L17_C4
-    poise_git_url_L17_C4 = Str("https://github.com/erg-lang/poise.git")
-    (print)(Str("Cloning poise (erg package manager) ..."),)
-    (os_L6).mkdir(Str(erg_tmp_dir_L14),) if (not ((
-    (os_L6).path
-    ).exists(Str(erg_tmp_dir_L14),))) else None
-    (os_L6).chdir(Str(erg_tmp_dir_L14),)
-    global res_L22_C4
-    res_L22_C4 = (sub_L9).run(List([Str("git"),Str("clone"),Str(poise_git_url_L17_C4),]),capture_output=Bool(True),)
-    (quit)(Str("Failed to clone poise repo"),) if (Int((res_L22_C4).returncode) != Nat(0)) else None
-    (os_L6).chdir(Str("poise"),)
-    (print)(Str("Building poise ..."),)
-    global res2_L27_C4
-    res2_L27_C4 = (sub_L9).run(List([((Str("") + (str__)(Str(erg_bin_dir_L13),)) + Str("/erg")),Str("src/main.er"),Str("--"),Str("install"),]),capture_output=Bool(True),)
-    if_tmp_func_1__()
-    (print)(Str("poise installed successfully"),)
-    (os_L6).chdir(Str(".."),)
-    return (su_L8).rmtree(Str("poise"),)
+        global tarfile_L122_C8
+        tarfile_L122_C8 = (tf_L1).open(fileobj=stream_L113,mode=Str("r|gz"),)
+        (tarfile_L122_C8).extractall(erg_tmp_dir_L17,)
+        if_tmp_17__ = (tarfile_L122_C8).close()
+    return if_tmp_17__
+tf_L1 = (__import__)(Str("tarfile"),)
+zf_L2 = (__import__)(Str("zipfile"),)
+json_L3 = (__import__)(Str("json"),)
+sys_L4 = (__import__)(Str("sys"),)
+os_L5 = (__import__)(Str("os"),)
+io_L6 = (__import__)(Str("io"),)
+su_L7 = (__import__)(Str("shutil"),)
+sub_L8 = (__import__)(Str("subprocess"),)
+__percent__v_desugar_1_L9 = (__import__)(Str("pathlib"),)
+Path_L9_C1 = (__percent__v_desugar_1_L9).Path
+__percent__v_desugar_2_L10 = (__import__)(Str("stat"),)
+S_IWRITE_L10_C1 = Nat((__percent__v_desugar_2_L10).S_IWRITE)
+__percent__v_desugar_3_L11 = (__import__)(Str("urllib"),)
+request_L11_C1 = (__percent__v_desugar_3_L11).request
 
-overwrite_L35 = mutate_operator(Bool(False))
-if_tmp_func_3__()
-(os_L6).mkdir(Str(erg_dir_L12),)
-(os_L6).mkdir(Str(erg_bin_dir_L13),)
-latest_version_L57 = if_tmp_func_12__()
-(print)(((Str("version: ") + (str__)(latest_version_L57,)) + Str("")),)
-filename_L75 = match_tmp_func_14__()
-url_L79 = ((((Str("https://github.com/erg-lang/erg/releases/download/") + (str__)(latest_version_L57,)) + Str("/")) + (str__)(Str(filename_L75),)) + Str(""))
-(print)(((Str("Downloading ") + (str__)(Str(url_L79),)) + Str(" ...")),)
-stream_L83 = (
-(urllib_L1).request
-).urlopen(Str(url_L79),)
-if_tmp_func_16__()
+home_dir_L14 = (Path_L9_C1).home()
+erg_dir_L15 = (home_dir_L14).joinpath(Str(".erg"),)
+erg_bin_dir_L16 = (erg_dir_L15).joinpath(Str("bin"),)
+erg_tmp_dir_L17 = (erg_dir_L15).joinpath(Str("tmp"),)
+platform_L19 = Str((sys_L4).platform)
+ext_L21 = Str("erg.exe") if (Str(platform_L19) == Str("win32")) else Str("erg")
+erg_bin_L25 = ((erg_bin_dir_L16).joinpath(Str(ext_L21),)).resolve()
+def remove_readonly__erg_proc___L28(func_L28_C17,path_L28_C23,_,):
+    (os_L5).chmod(path_L28_C23,Nat(S_IWRITE_L10_C1),)
+    return (func_L28_C17)(path_L28_C23,)
+
+def install_poise__erg_proc___L34():
+    (print)(Str("Cloning poise (erg package manager) ..."),)
+    (erg_tmp_dir_L17).mkdir(parents=Bool(True),exist_ok=Bool(True),) if (not ((erg_tmp_dir_L17).exists())) else None
+    (os_L5).chdir(erg_tmp_dir_L17,)
+    global poise_L42_C4
+    poise_L42_C4 = (Path_L9_C1)(Str("poise"),)
+    if_tmp_func_1__()
+    (os_L5).chdir(poise_L42_C4,)
+    (print)(Str("Building poise ..."),)
+    global poise_main_path_L52_C4
+    poise_main_path_L52_C4 = (Path_L9_C1)(Str("src"),Str("main.er"),)
+    global cmd_L53_C4
+    cmd_L53_C4 = List([((Str("") + (str__)(erg_bin_L25,)) + Str("")),((Str("") + (str__)(poise_main_path_L52_C4,)) + Str("")),Str("--"),Str("install"),])
+    global install_res_L54_C4
+    install_res_L54_C4 = (sub_L8).run(List(cmd_L53_C4),capture_output=Bool(True),)
+    if_tmp_func_3__()
+    (print)(Str("poise installed successfully"),)
+    (os_L5).chdir(Str(".."),)
+    return (su_L7).rmtree(poise_L42_C4,onerror=remove_readonly__erg_proc___L28,)
+
+is_overwrite_L65 = mutate_operator(Bool(False))
+if_tmp_func_5__()
+(erg_dir_L15).mkdir(parents=Bool(True),exist_ok=Bool(True),)
+(erg_bin_dir_L16).mkdir(parents=Bool(True),exist_ok=Bool(True),)
+latest_version_L87 = if_tmp_func_14__()
+(print)(((Str("version: ") + (str__)(latest_version_L87,)) + Str("")),)
+filename_L106 = match_tmp_func_16__()
+url_L110 = ((((Str("https://github.com/erg-lang/erg/releases/download/") + (str__)(latest_version_L87,)) + Str("/")) + (str__)(Str(filename_L106),)) + Str(""))
+(print)(((Str("Downloading ") + (str__)(Str(url_L110),)) + Str(" ...")),)
+stream_L113 = (request_L11_C1).urlopen(Str(url_L110),)
+(print)(((Str("Extracting ") + (str__)(Str(filename_L106),)) + Str(" ...")),)
+if_tmp_func_18__()
+erg_tmp_bin_L126 = (erg_tmp_dir_L17).joinpath(Str(ext_L21),)
+(discard__)((su_L7).move(erg_tmp_bin_L126,erg_bin_L25,),)
+(discard__)((su_L7).move((erg_tmp_dir_L17).joinpath(Str("lib"),),(erg_dir_L15).joinpath(Str("lib"),),),)
+(su_L7).rmtree(erg_tmp_dir_L17,onerror=remove_readonly__erg_proc___L28,)
 (print)(Str("erg installed successfully"),)
-(install_poise__erg_proc___L16)()
-(print)(((((Str("Please add `.erg` to your PATH by running `export PATH=$PATH:") + (str__)(Str(erg_bin_dir_L13),)) + Str("` and `export ERG_PATH=")) + (str__)(Str(erg_dir_L12),)) + Str("`")),) if (not (overwrite_L35)) else None
+(install_poise__erg_proc___L34)()
+(print)(((((Str("Please add `.erg` to your PATH by running `export PATH=$PATH:") + (str__)(erg_bin_dir_L16,)) + Str("` and `export ERG_PATH=")) + (str__)(erg_dir_L15,)) + Str("`")),) if (not (is_overwrite_L65)) else None


### PR DESCRIPTION
## Caution

https://github.com/erg-lang/erg/pull/526

This has updated the Generator, so the error occurs in erg stable versions

```sh
python3 <(curl -L https://github.com/mtshiba/ergup/raw/main/ergup.py) - nightly
```

## Refactor

- partial utilization
   - Path in pathlib
   - request in urllib

## Fix

ref to: https://docs.python.org/3.11/library/shutil.html#rmtree-example

In windows11(or 10),  .git marks as read-only and hidden when poise is cloned from github

so, make it writable and delete
